### PR TITLE
댓글 date 타입 수정

### DIFF
--- a/pins/Domain/Entity/CommentRequest.swift
+++ b/pins/Domain/Entity/CommentRequest.swift
@@ -12,5 +12,5 @@ struct CommentRequest: Codable {
     let pinId: String
     let userId: String
     let content: String
-    let createdAt: String
+    let createdAt: Date
 }

--- a/pins/Domain/Entity/CommentResponse.swift
+++ b/pins/Domain/Entity/CommentResponse.swift
@@ -39,6 +39,6 @@ struct CommentResponse {
         self.userProfile = profile
         self.userDescription = user.description ?? ""
         self.content = commentRequest.content
-        self.createdAt = commentRequest.createdAt.convertDaysAgo()
+        self.createdAt = commentRequest.createdAt.currentDateTimeAsString().convertDaysAgo()
     }
 }

--- a/pins/Domain/UseCase/DetailUseCase.swift
+++ b/pins/Domain/UseCase/DetailUseCase.swift
@@ -32,7 +32,7 @@ final class DetailUseCase: DetailUseCaseProtocol {
             pinId: pinId,
             userId: userId,
             content: text,
-            createdAt: Date().currentDateTimeAsString()))
+            createdAt: Date()))
         } catch {
             throw error
         }

--- a/pins/Extension/String+Extensions.swift
+++ b/pins/Extension/String+Extensions.swift
@@ -49,10 +49,10 @@ extension String {
     
     func birthDateToAge() -> Int {
         String.dateFormatter.dateFormat = "yyMMdd"
-        let birthDate = String.dateFormatter.date(from: self)
+        let birthDate = String.dateFormatter.date(from: self) ?? Date()
         let calendar = Calendar.current
-        let ageComponents = calendar.dateComponents([.year], from: birthDate!, to: Date())
-        let age = ageComponents.year!
+        let ageComponents = calendar.dateComponents([.year], from: birthDate, to: Date())
+        let age = ageComponents.year ?? 0
         return age
     }
 }

--- a/pinsTests/MockClass.swift
+++ b/pinsTests/MockClass.swift
@@ -49,7 +49,7 @@ final class MockFirestorageService: FirestorageServiceProtocol {
 }
 
 final class MockCommentService: CommentServiceProtocol {
-    var mockComment: [CommentRequest] = [CommentRequest(id: "testId", pinId: "testPin", userId: "testUserId", content: "testComment", createdAt: "")]
+    var mockComment: [CommentRequest] = [CommentRequest(id: "testId", pinId: "testPin", userId: "testUserId", content: "testComment", createdAt: Date())]
     func getComments(pinId: String) async -> [pins.CommentRequest] {
         return mockComment
     }


### PR DESCRIPTION
firestore에 댓글 저장 시 날짜 정보를 String에서 Date로 수정했습니다.
추가로 댓글 순서가 정상적으로 나오지 않는 문제를 해결했습니다.